### PR TITLE
Add package, file and function info

### DIFF
--- a/pkg/core/plog.go
+++ b/pkg/core/plog.go
@@ -38,6 +38,8 @@ func Warn(msg string) {
 		log.WithFields(getAdditionalFields(pc, file)).Warn(msg)
 		return
 	}
+
+	log.Warn(msg)
 }
 
 func Error(msg string) {
@@ -46,6 +48,8 @@ func Error(msg string) {
 		log.WithFields(getAdditionalFields(pc, file)).Error(msg)
 		return
 	}
+
+	log.Error(msg)
 }
 
 func getAdditionalFields(pc uintptr, file string) log.Fields {

--- a/pkg/core/plog.go
+++ b/pkg/core/plog.go
@@ -1,29 +1,64 @@
 package core
 
 import (
+	"runtime"
+	"strings"
+
 	log "github.com/sirupsen/logrus"
 )
 
 func Init() {
-	log.SetFormatter(&log.TextFormatter{
-		DisableColors: true,
-		FullTimestamp: true,
-	})
-	//log.SetLevel(log.DebugLevel) //Note this must be enabled from the application
+	log.SetFormatter(&log.JSONFormatter{})
+	// log.SetLevel(log.DebugLevel) //Note this must be enabled from the application
 }
 
-func Info(args ...interface{}) {
-	log.Info(args)
+func Info(msg string) {
+	pc, file, _, ok := runtime.Caller(1)
+	if ok {
+		log.WithFields(getAdditionalFields(pc, file)).Info(msg)
+		return
+	}
+
+	log.Info(msg)
 }
 
-func Debug(args ...interface{}) {
-	log.Debug(args)
+func Debug(msg string) {
+	pc, file, _, ok := runtime.Caller(1)
+	if ok {
+		log.WithFields(getAdditionalFields(pc, file)).Debug(msg)
+		return
+	}
+
+	log.Debug(msg)
 }
 
-func Warn(args ...interface{}) {
-	log.Warn(args)
+func Warn(msg string) {
+	pc, file, _, ok := runtime.Caller(1)
+	if ok {
+		log.WithFields(getAdditionalFields(pc, file)).Warn(msg)
+		return
+	}
 }
 
-func Error(args ...interface{}) {
-	log.Error(args)
+func Error(msg string) {
+	pc, file, _, ok := runtime.Caller(1)
+	if ok {
+		log.WithFields(getAdditionalFields(pc, file)).Error(msg)
+		return
+	}
+}
+
+func getAdditionalFields(pc uintptr, file string) log.Fields {
+	details := runtime.FuncForPC(pc)
+	if details != nil {
+		fn := strings.Split(details.Name(), ".")
+		fields := log.Fields{
+			"package":  fn[0],
+			"function": fn[1],
+			"file":     file,
+		}
+		return fields
+	}
+
+	return log.Fields{}
 }

--- a/pkg/core/plog.go
+++ b/pkg/core/plog.go
@@ -8,6 +8,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+type Fields map[string]interface{}
+
 func Init() {
 	log.SetFormatter(&log.JSONFormatter{})
 	// log.SetLevel(log.DebugLevel) //Note this must be enabled from the application
@@ -33,6 +35,25 @@ func Infof(s string, args ...interface{}) {
 	log.Infof(s, args...)
 }
 
+func InfoWithAdditionalFields(s string, args interface{}) {
+	pc, file, line, ok := runtime.Caller(1)
+	if ok {
+		l := log.WithFields(getAdditionalFields(pc, file, line))
+		l = mergeAddionalFields(l, args)
+		l.Info(s)
+		return
+	}
+
+	af, ok := args.(map[string]interface{})
+	if ok {
+		l := log.WithFields(af)
+		l.Info(s)
+		return
+	}
+
+	log.Info(s)
+}
+
 func Debug(msg string) {
 	pc, file, line, ok := runtime.Caller(1)
 	if ok {
@@ -51,6 +72,25 @@ func Debugf(s string, args ...interface{}) {
 	}
 
 	log.Debugf(s, args...)
+}
+
+func DebugWithAdditionalFields(s string, args interface{}) {
+	pc, file, line, ok := runtime.Caller(1)
+	if ok {
+		l := log.WithFields(getAdditionalFields(pc, file, line))
+		l = mergeAddionalFields(l, args)
+		l.Debug(s)
+		return
+	}
+
+	af, ok := args.(map[string]interface{})
+	if ok {
+		l := log.WithFields(af)
+		l.Debug(s)
+		return
+	}
+
+	log.Debug(s)
 }
 
 func Warn(msg string) {
@@ -73,6 +113,25 @@ func Warnf(s string, args ...interface{}) {
 	log.Warnf(s, args...)
 }
 
+func WarnWithAdditionalFields(s string, args interface{}) {
+	pc, file, line, ok := runtime.Caller(1)
+	if ok {
+		l := log.WithFields(getAdditionalFields(pc, file, line))
+		l = mergeAddionalFields(l, args)
+		l.Warn(s)
+		return
+	}
+
+	af, ok := args.(map[string]interface{})
+	if ok {
+		l := log.WithFields(af)
+		l.Warn(s)
+		return
+	}
+
+	log.Warn(s)
+}
+
 func Error(msg string) {
 	pc, file, line, ok := runtime.Caller(1)
 	if ok {
@@ -93,6 +152,25 @@ func Errorf(s string, args ...interface{}) {
 	log.Errorf(s, args...)
 }
 
+func ErrorWithAdditionalFields(s string, args interface{}) {
+	pc, file, line, ok := runtime.Caller(1)
+	if ok {
+		l := log.WithFields(getAdditionalFields(pc, file, line))
+		l = mergeAddionalFields(l, args)
+		l.Error(s)
+		return
+	}
+
+	af, ok := args.(map[string]interface{})
+	if ok {
+		l := log.WithFields(af)
+		l.Error(s)
+		return
+	}
+
+	log.Error(s)
+}
+
 func getAdditionalFields(pc uintptr, file string, line int) log.Fields {
 	details := runtime.FuncForPC(pc)
 	if details != nil {
@@ -106,4 +184,14 @@ func getAdditionalFields(pc uintptr, file string, line int) log.Fields {
 	}
 
 	return log.Fields{}
+}
+
+func mergeAddionalFields(l *log.Entry, args interface{}) *log.Entry {
+	af, ok := args.(map[string]interface{})
+	if ok {
+		l = l.WithFields(af)
+		return l
+	}
+
+	return l
 }

--- a/pkg/core/plog.go
+++ b/pkg/core/plog.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"runtime"
 	"strings"
 
@@ -13,9 +14,9 @@ func Init() {
 }
 
 func Info(msg string) {
-	pc, file, _, ok := runtime.Caller(1)
+	pc, file, line, ok := runtime.Caller(1)
 	if ok {
-		log.WithFields(getAdditionalFields(pc, file)).Info(msg)
+		log.WithFields(getAdditionalFields(pc, file, line)).Info(msg)
 		return
 	}
 
@@ -23,9 +24,9 @@ func Info(msg string) {
 }
 
 func Debug(msg string) {
-	pc, file, _, ok := runtime.Caller(1)
+	pc, file, line, ok := runtime.Caller(1)
 	if ok {
-		log.WithFields(getAdditionalFields(pc, file)).Debug(msg)
+		log.WithFields(getAdditionalFields(pc, file, line)).Debug(msg)
 		return
 	}
 
@@ -33,9 +34,9 @@ func Debug(msg string) {
 }
 
 func Warn(msg string) {
-	pc, file, _, ok := runtime.Caller(1)
+	pc, file, line, ok := runtime.Caller(1)
 	if ok {
-		log.WithFields(getAdditionalFields(pc, file)).Warn(msg)
+		log.WithFields(getAdditionalFields(pc, file, line)).Warn(msg)
 		return
 	}
 
@@ -43,23 +44,23 @@ func Warn(msg string) {
 }
 
 func Error(msg string) {
-	pc, file, _, ok := runtime.Caller(1)
+	pc, file, line, ok := runtime.Caller(1)
 	if ok {
-		log.WithFields(getAdditionalFields(pc, file)).Error(msg)
+		log.WithFields(getAdditionalFields(pc, file, line)).Error(msg)
 		return
 	}
 
 	log.Error(msg)
 }
 
-func getAdditionalFields(pc uintptr, file string) log.Fields {
+func getAdditionalFields(pc uintptr, file string, line int) log.Fields {
 	details := runtime.FuncForPC(pc)
 	if details != nil {
 		fn := strings.Split(details.Name(), ".")
 		fields := log.Fields{
 			"package":  fn[0],
 			"function": fn[1],
-			"file":     file,
+			"file":     fmt.Sprintf("%s:%d", file, line),
 		}
 		return fields
 	}

--- a/pkg/core/plog.go
+++ b/pkg/core/plog.go
@@ -23,6 +23,16 @@ func Info(msg string) {
 	log.Info(msg)
 }
 
+func Infof(s string, args ...interface{}) {
+	pc, file, line, ok := runtime.Caller(1)
+	if ok {
+		log.WithFields(getAdditionalFields(pc, file, line)).Infof(s, args...)
+		return
+	}
+
+	log.Infof(s, args...)
+}
+
 func Debug(msg string) {
 	pc, file, line, ok := runtime.Caller(1)
 	if ok {
@@ -31,6 +41,16 @@ func Debug(msg string) {
 	}
 
 	log.Debug(msg)
+}
+
+func Debugf(s string, args ...interface{}) {
+	pc, file, line, ok := runtime.Caller(1)
+	if ok {
+		log.WithFields(getAdditionalFields(pc, file, line)).Debugf(s, args...)
+		return
+	}
+
+	log.Debugf(s, args...)
 }
 
 func Warn(msg string) {
@@ -43,6 +63,16 @@ func Warn(msg string) {
 	log.Warn(msg)
 }
 
+func Warnf(s string, args ...interface{}) {
+	pc, file, line, ok := runtime.Caller(1)
+	if ok {
+		log.WithFields(getAdditionalFields(pc, file, line)).Warnf(s, args...)
+		return
+	}
+
+	log.Warnf(s, args...)
+}
+
 func Error(msg string) {
 	pc, file, line, ok := runtime.Caller(1)
 	if ok {
@@ -51,6 +81,16 @@ func Error(msg string) {
 	}
 
 	log.Error(msg)
+}
+
+func Errorf(s string, args ...interface{}) {
+	pc, file, line, ok := runtime.Caller(1)
+	if ok {
+		log.WithFields(getAdditionalFields(pc, file, line)).Errorf(s, args...)
+		return
+	}
+
+	log.Errorf(s, args...)
 }
 
 func getAdditionalFields(pc uintptr, file string, line int) log.Fields {

--- a/test/plog_test.go
+++ b/test/plog_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"fmt"
 	"testing"
 
 	logger "github.com/phil-inc/plog-ng/pkg/core"
@@ -9,8 +8,8 @@ import (
 
 func TestConnectivity(t *testing.T) {
 	logger.Init()
-	logger.Info(fmt.Sprintf("test message %s", "special value"))
-	logger.Debug(fmt.Sprintf("test message %s", "special value"))
-	logger.Error(fmt.Sprintf("test message %s", "special value"))
-	logger.Warn(fmt.Sprintf("test message %s", "special value"))
+	logger.Info("test message")
+	logger.Debug("test message")
+	logger.Error("test message")
+	logger.Warn("test message")
 }

--- a/test/plog_test.go
+++ b/test/plog_test.go
@@ -12,4 +12,8 @@ func TestConnectivity(t *testing.T) {
 	logger.Debug("test message")
 	logger.Error("test message")
 	logger.Warn("test message")
+	logger.Infof("test message %s", "special value")
+	logger.Debugf("test message %s", "special value")
+	logger.Errorf("test message %s", "special value")
+	logger.Warnf("test message %s", "special value")
 }

--- a/test/plog_test.go
+++ b/test/plog_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"testing"
 
 	logger "github.com/phil-inc/plog-ng/pkg/core"
@@ -8,8 +9,8 @@ import (
 
 func TestConnectivity(t *testing.T) {
 	logger.Init()
-	logger.Info("test message %s", "special value")
-	logger.Debug("test message %s", "special value")
-	logger.Error("test message %s", "special value")
-	logger.Warn("test message %s", "special value")
+	logger.Info(fmt.Sprintf("test message %s", "special value"))
+	logger.Debug(fmt.Sprintf("test message %s", "special value"))
+	logger.Error(fmt.Sprintf("test message %s", "special value"))
+	logger.Warn(fmt.Sprintf("test message %s", "special value"))
 }


### PR DESCRIPTION
## Description
- Change the formatter to JSON
- Automatically add package, file, and function attributes to log

Example:
`{"file":"<full-path>/main.go","function":"test","level":"info","msg":"Test","package":"main","time":"2022-09-01T13:39:56+05:45"}`