### PR TITLE
Allow users to set the logging level without importing logrus directly

### DIFF
--- a/pkg/core/export.go
+++ b/pkg/core/export.go
@@ -6,6 +6,31 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	// PanicLevel level, highest level of severity. Logs and then calls panic with the
+	// message passed to Debug, Info, ...
+	PanicLevel log.Level = iota
+	// FatalLevel level. Logs and then calls `logger.Exit(1)`. It will exit even if the
+	// logging level is set to Panic.
+	FatalLevel
+	// ErrorLevel level. Logs. Used for errors that should definitely be noted.
+	// Commonly used for hooks to send errors to an error tracking service.
+	ErrorLevel
+	// WarnLevel level. Non-critical entries that deserve eyes.
+	WarnLevel
+	// InfoLevel level. General operational entries about what's going on inside the
+	// application.
+	InfoLevel
+	// DebugLevel level. Usually only enabled when debugging. Very verbose logging.
+	DebugLevel
+	// TraceLevel level. Designates finer-grained informational events than the Debug.
+	TraceLevel
+)
+
+func SetLevel(level log.Level) {
+	log.SetLevel(level)
+}
+
 func WithFields(fields Fields) *entry {
 	e.Entry = log.NewEntry(log.StandardLogger())
 	e.Entry = e.WithFields((log.Fields)(fields))

--- a/test/plog_test.go
+++ b/test/plog_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestConnectivity(t *testing.T) {
 	logger.Init()
+	logger.SetLevel(logger.InfoLevel)
 	logger.Info("test message")
 	logger.Debug("test message")
 	logger.Error("test message")


### PR DESCRIPTION
Exports the log level constants and a function to set them so that the log level is accessible from plog instead of logrus.