### PR TITLE
Export function to retrieve log level

### DIFF
--- a/pkg/core/export.go
+++ b/pkg/core/export.go
@@ -31,6 +31,10 @@ func SetLevel(level log.Level) {
 	log.SetLevel(level)
 }
 
+func GetLevel() log.Level {
+	return log.GetLevel()
+}
+
 func WithFields(fields Fields) *entry {
 	e.Entry = log.NewEntry(log.StandardLogger())
 	e.Entry = e.WithFields((log.Fields)(fields))

--- a/test/plog_test.go
+++ b/test/plog_test.go
@@ -9,6 +9,7 @@ import (
 func TestConnectivity(t *testing.T) {
 	logger.Init()
 	logger.SetLevel(logger.InfoLevel)
+	logger.GetLevel()
 	logger.Info("test message")
 	logger.Debug("test message")
 	logger.Error("test message")


### PR DESCRIPTION
We allow users of plog-ng to set the logging level. This allows them to retrieve at as well.