### PR TITLE
Add WithContext function

### DIFF
--- a/pkg/core/plog.go
+++ b/pkg/core/plog.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"strings"
@@ -24,6 +25,11 @@ func Init() {
 
 func (entry *entry) WithCallerLevel(l int) *entry {
 	entry.level = &l
+	return entry
+}
+
+func (entry *entry) WithContext(ctx context.Context) *entry {
+	entry.Entry = log.WithContext(ctx)
 	return entry
 }
 


### PR DESCRIPTION
##Description
- Currently, when the `WithContext` is used, it directly uses logrus package `WithContext` function; hence, the file and the line number are not seen in the logged lines.
- This change ensures that we use the logging function in this package to display the file and the line number in the logs.