### PR TITLE
Update to use logrus  withcontext function

### DIFF
--- a/pkg/core/plog.go
+++ b/pkg/core/plog.go
@@ -29,7 +29,7 @@ func (entry *entry) WithCallerLevel(l int) *entry {
 }
 
 func (entry *entry) WithContext(ctx context.Context) *entry {
-	entry.Entry = log.WithContext(ctx)
+	entry.Entry.WithContext(ctx)
 	return entry
 }
 


### PR DESCRIPTION
## Description
- The WithFields is getting overridden by WithContext. Use ebtry level function instead of log level.